### PR TITLE
Add support for Keep-a-Changelog's links in the heading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 
 ### Added
 
-- Added support for Keep-a-Changelog's links in the heading
-- Added support for using en dashes instead of minus signs
+- Added support for Keep-a-Changelog's links in the heading [#2]
+- Added support for using en dashes instead of minus signs [#2]
 - Added support for passing multiple parameters to `markdown-lint` [#3]
 
 ## v1.1.0 - 2020-02-11
@@ -44,6 +44,7 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 
 [keepachangelog]:https://keepachangelog.com/en/1.0.0/
 [semver]:https://semver.org/spec/v2.0.0.html
+[#2]:https://github.com/avto-dev/markdown-lint/pull/2
 [#3]:https://github.com/avto-dev/markdown-lint/pull/3
 
 <!-- markdownlint-disable-file MD024 -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## Unreleased
+
+### Added
+
+- Added support for Keep-a-Changelog's links in the heading
+- Added support for using en dashes instead of minus signs
+
 ## v1.1.0 - 2020-02-11
 
 ### Added
@@ -36,3 +43,5 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 
 [keepachangelog]:https://keepachangelog.com/en/1.0.0/
 [semver]:https://semver.org/spec/v2.0.0.html
+
+<!-- markdownlint-disable-file MD024 -->

--- a/lint/rules/changelog.js
+++ b/lint/rules/changelog.js
@@ -9,15 +9,23 @@ module.exports = [{
             return token.type === "heading_open";
         }).forEach(function forToken(token) {
             if (token.tag === "h2") {
-                if (/^## [vV]?\d+\.\d+\.\d+(-[0-9A-Za-z-.]+|)$/m.test(token.line)) {
+                if (/^## [vV]?\d+\.\d+\.\d+(-[0-9A-Za-z-.]+|)?$/m.test(token.line)) {
                     return;
                 }
-
-                if (/^## [vV]?\d+\.\d+\.\d+(-[0-9A-Za-z-.]+|) - 20[12][0-9]-[01][0-9]-[0-3][0-9]$/m.test(token.line)) {
+                if (/^## \[[vV]?\d+\.\d+\.\d+(-[0-9A-Za-z-.]+|)?]$/m.test(token.line)) {
+                    return;
+                }
+                if (/^## [vV]?\d+\.\d+\.\d+(-[0-9A-Za-z-.]+|) [-–] 20[12][0-9]-[01][0-9]-[0-3][0-9]$/m.test(token.line)) {
+                    return;
+                }
+                if (/^## \[[vV]?\d+\.\d+\.\d+(-[0-9A-Za-z-.]+|)\] [-–] 20[12][0-9]-[01][0-9]-[0-3][0-9]$/m.test(token.line)) {
                     return;
                 }
 
                 if (/^## unreleased$/mi.test(token.line)) {
+                    return;
+                }
+                if (/^## \[unreleased\]$/mi.test(token.line)) {
                     return;
                 }
 

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -35,11 +35,16 @@ runChangelogTest() {
 }
 
 runChangelogTest ./samples/changelog/correct/sample-1.md false
+runChangelogTest ./samples/changelog/correct/sample-2.md false
+runChangelogTest ./samples/changelog/correct/sample-3.md false
+runChangelogTest ./samples/changelog/correct/keepachangelog-1.0.0.md false
+runChangelogTest ./samples/changelog/correct/keepachangelog-1.0.0-with-en-dash.md false
 runChangelogTest ./samples/changelog/incorrect/changes-list-with-ends-punctuation-1.md true "Lists items without punctuation"
 runChangelogTest ./samples/changelog/incorrect/changes-list-with-ends-punctuation-2.md true "Lists items without punctuation"
 runChangelogTest ./samples/changelog/incorrect/incorrect-cahnges-type-1.md true "Type of changes format"
 runChangelogTest ./samples/changelog/incorrect/incorrect-cahnges-type-2.md true "Type of changes format"
 runChangelogTest ./samples/changelog/incorrect/missed-first-header.md true "First line in file should be a top"
+runChangelogTest ./samples/changelog/incorrect/no-proper-link.md true "Version header format"
 runChangelogTest ./samples/changelog/incorrect/wrong-version-header-1.md true "Version header format"
 runChangelogTest ./samples/changelog/incorrect/wrong-version-header-2.md true "Version header format"
 runChangelogTest ./samples/changelog/incorrect/wrong-version-header-3.md true "Version header format"

--- a/tests/samples/changelog/correct/keepachangelog-1.0.0-with-en-dash.md
+++ b/tests/samples/changelog/correct/keepachangelog-1.0.0-with-en-dash.md
@@ -1,0 +1,153 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0] – 2017-06-20
+### Added
+- New visual identity by [@tylerfortune8](https://github.com/tylerfortune8).
+- Version navigation.
+- Links to latest released version in previous versions.
+- "Why keep a changelog?" section.
+- "Who needs a changelog?" section.
+- "How do I make a changelog?" section.
+- "Frequently Asked Questions" section.
+- New "Guiding Principles" sub-section to "How do I make a changelog?".
+- Simplified and Traditional Chinese translations from [@tianshuo](https://github.com/tianshuo).
+- German translation from [@mpbzh](https://github.com/mpbzh) & [@Art4](https://github.com/Art4).
+- Italian translation from [@azkidenz](https://github.com/azkidenz).
+- Swedish translation from [@magol](https://github.com/magol).
+- Turkish translation from [@karalamalar](https://github.com/karalamalar).
+- French translation from [@zapashcanon](https://github.com/zapashcanon).
+- Brazilian Portugese translation from [@Webysther](https://github.com/Webysther).
+- Polish translation from [@amielucha](https://github.com/amielucha) & [@m-aciek](https://github.com/m-aciek).
+- Russian translation from [@aishek](https://github.com/aishek).
+- Czech translation from [@h4vry](https://github.com/h4vry).
+- Slovak translation from [@jkostolansky](https://github.com/jkostolansky).
+- Korean translation from [@pierceh89](https://github.com/pierceh89).
+- Croatian translation from [@porx](https://github.com/porx).
+- Persian translation from [@Hameds](https://github.com/Hameds).
+- Ukrainian translation from [@osadchyi-s](https://github.com/osadchyi-s).
+
+### Changed
+- Start using "changelog" over "change log" since it's the common usage.
+- Start versioning based on the current English version at 0.3.0 to help
+translation authors keep things up-to-date.
+- Rewrite "What makes unicorns cry?" section.
+- Rewrite "Ignoring Deprecations" sub-section to clarify the ideal
+  scenario.
+- Improve "Commit log diffs" sub-section to further argument against
+  them.
+- Merge "Why can’t people just use a git log diff?" with "Commit log
+  diffs"
+- Fix typos in Simplified Chinese and Traditional Chinese translations.
+- Fix typos in Brazilian Portuguese translation.
+- Fix typos in Turkish translation.
+- Fix typos in Czech translation.
+- Fix typos in Swedish translation.
+- Improve phrasing in French translation.
+- Fix phrasing and spelling in German translation.
+
+### Removed
+- Section about "changelog" vs "CHANGELOG".
+
+## [0.3.0] – 2015-12-03
+### Added
+- RU translation from [@aishek](https://github.com/aishek).
+- pt-BR translation from [@tallesl](https://github.com/tallesl).
+- es-ES translation from [@ZeliosAriex](https://github.com/ZeliosAriex).
+
+## [0.2.0] – 2015-10-06
+### Changed
+- Remove exclusionary mentions of "open source" since this project can
+benefit both "open" and "closed" source projects equally.
+
+## [0.1.0] – 2015-10-06
+### Added
+- Answer "Should you ever rewrite a change log?".
+
+### Changed
+- Improve argument against commit logs.
+- Start following [SemVer](https://semver.org) properly.
+
+## [0.0.8] – 2015-02-17
+### Changed
+- Update year to match in every README example.
+- Reluctantly stop making fun of Brits only, since most of the world
+  writes dates in a strange way.
+
+### Fixed
+- Fix typos in recent README changes.
+- Update outdated unreleased diff link.
+
+## [0.0.7] – 2015-02-16
+### Added
+- Link, and make it obvious that date format is ISO 8601.
+
+### Changed
+- Clarified the section on "Is there a standard change log format?".
+
+### Fixed
+- Fix Markdown links to tag comparison URL with footnote-style links.
+
+## [0.0.6] – 2014-12-12
+### Added
+- README section on "yanked" releases.
+
+## [0.0.5] – 2014-08-09
+### Added
+- Markdown links to version tags on release headings.
+- Unreleased section to gather unreleased changes and encourage note
+keeping prior to releases.
+
+## [0.0.4] – 2014-08-09
+### Added
+- Better explanation of the difference between the file ("CHANGELOG")
+and its function "the change log".
+
+### Changed
+- Refer to a "change log" instead of a "CHANGELOG" throughout the site
+to differentiate between the file and the purpose of the file — the
+logging of changes.
+
+### Removed
+- Remove empty sections from CHANGELOG, they occupy too much space and
+create too much noise in the file. People will have to assume that the
+missing sections were intentionally left out because they contained no
+notable changes.
+
+## [0.0.3] – 2014-08-09
+### Added
+- "Why should I care?" section mentioning The Changelog podcast.
+
+## [0.0.2] – 2014-07-10
+### Added
+- Explanation of the recommended reverse chronological release ordering.
+
+## [0.0.1] – 2014-05-31
+### Added
+- This CHANGELOG file to hopefully serve as an evolving example of a
+  standardized open source project CHANGELOG.
+- CNAME file to enable GitHub Pages custom domain
+- README now contains answers to common questions about CHANGELOGs
+- Good examples and basic guidelines, including proper date formatting.
+- Counter-examples: "What makes unicorns cry?"
+
+[Unreleased]: https://github.com/olivierlacan/keep-a-changelog/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.3.0...v1.0.0
+[0.3.0]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.8...v0.1.0
+[0.0.8]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.7...v0.0.8
+[0.0.7]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.6...v0.0.7
+[0.0.6]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.5...v0.0.6
+[0.0.5]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.4...v0.0.5
+[0.0.4]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.3...v0.0.4
+[0.0.3]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.2...v0.0.3
+[0.0.2]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.1...v0.0.2
+[0.0.1]: https://github.com/olivierlacan/keep-a-changelog/releases/tag/v0.0.1
+
+<!-- markdownlint-disable-file MD022 MD032 CHANGELOG-RULE-003 -->

--- a/tests/samples/changelog/correct/keepachangelog-1.0.0.md
+++ b/tests/samples/changelog/correct/keepachangelog-1.0.0.md
@@ -1,0 +1,153 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0] - 2017-06-20
+### Added
+- New visual identity by [@tylerfortune8](https://github.com/tylerfortune8).
+- Version navigation.
+- Links to latest released version in previous versions.
+- "Why keep a changelog?" section.
+- "Who needs a changelog?" section.
+- "How do I make a changelog?" section.
+- "Frequently Asked Questions" section.
+- New "Guiding Principles" sub-section to "How do I make a changelog?".
+- Simplified and Traditional Chinese translations from [@tianshuo](https://github.com/tianshuo).
+- German translation from [@mpbzh](https://github.com/mpbzh) & [@Art4](https://github.com/Art4).
+- Italian translation from [@azkidenz](https://github.com/azkidenz).
+- Swedish translation from [@magol](https://github.com/magol).
+- Turkish translation from [@karalamalar](https://github.com/karalamalar).
+- French translation from [@zapashcanon](https://github.com/zapashcanon).
+- Brazilian Portugese translation from [@Webysther](https://github.com/Webysther).
+- Polish translation from [@amielucha](https://github.com/amielucha) & [@m-aciek](https://github.com/m-aciek).
+- Russian translation from [@aishek](https://github.com/aishek).
+- Czech translation from [@h4vry](https://github.com/h4vry).
+- Slovak translation from [@jkostolansky](https://github.com/jkostolansky).
+- Korean translation from [@pierceh89](https://github.com/pierceh89).
+- Croatian translation from [@porx](https://github.com/porx).
+- Persian translation from [@Hameds](https://github.com/Hameds).
+- Ukrainian translation from [@osadchyi-s](https://github.com/osadchyi-s).
+
+### Changed
+- Start using "changelog" over "change log" since it's the common usage.
+- Start versioning based on the current English version at 0.3.0 to help
+translation authors keep things up-to-date.
+- Rewrite "What makes unicorns cry?" section.
+- Rewrite "Ignoring Deprecations" sub-section to clarify the ideal
+  scenario.
+- Improve "Commit log diffs" sub-section to further argument against
+  them.
+- Merge "Why can’t people just use a git log diff?" with "Commit log
+  diffs"
+- Fix typos in Simplified Chinese and Traditional Chinese translations.
+- Fix typos in Brazilian Portuguese translation.
+- Fix typos in Turkish translation.
+- Fix typos in Czech translation.
+- Fix typos in Swedish translation.
+- Improve phrasing in French translation.
+- Fix phrasing and spelling in German translation.
+
+### Removed
+- Section about "changelog" vs "CHANGELOG".
+
+## [0.3.0] - 2015-12-03
+### Added
+- RU translation from [@aishek](https://github.com/aishek).
+- pt-BR translation from [@tallesl](https://github.com/tallesl).
+- es-ES translation from [@ZeliosAriex](https://github.com/ZeliosAriex).
+
+## [0.2.0] - 2015-10-06
+### Changed
+- Remove exclusionary mentions of "open source" since this project can
+benefit both "open" and "closed" source projects equally.
+
+## [0.1.0] - 2015-10-06
+### Added
+- Answer "Should you ever rewrite a change log?".
+
+### Changed
+- Improve argument against commit logs.
+- Start following [SemVer](https://semver.org) properly.
+
+## [0.0.8] - 2015-02-17
+### Changed
+- Update year to match in every README example.
+- Reluctantly stop making fun of Brits only, since most of the world
+  writes dates in a strange way.
+
+### Fixed
+- Fix typos in recent README changes.
+- Update outdated unreleased diff link.
+
+## [0.0.7] - 2015-02-16
+### Added
+- Link, and make it obvious that date format is ISO 8601.
+
+### Changed
+- Clarified the section on "Is there a standard change log format?".
+
+### Fixed
+- Fix Markdown links to tag comparison URL with footnote-style links.
+
+## [0.0.6] - 2014-12-12
+### Added
+- README section on "yanked" releases.
+
+## [0.0.5] - 2014-08-09
+### Added
+- Markdown links to version tags on release headings.
+- Unreleased section to gather unreleased changes and encourage note
+keeping prior to releases.
+
+## [0.0.4] - 2014-08-09
+### Added
+- Better explanation of the difference between the file ("CHANGELOG")
+and its function "the change log".
+
+### Changed
+- Refer to a "change log" instead of a "CHANGELOG" throughout the site
+to differentiate between the file and the purpose of the file — the
+logging of changes.
+
+### Removed
+- Remove empty sections from CHANGELOG, they occupy too much space and
+create too much noise in the file. People will have to assume that the
+missing sections were intentionally left out because they contained no
+notable changes.
+
+## [0.0.3] - 2014-08-09
+### Added
+- "Why should I care?" section mentioning The Changelog podcast.
+
+## [0.0.2] - 2014-07-10
+### Added
+- Explanation of the recommended reverse chronological release ordering.
+
+## [0.0.1] - 2014-05-31
+### Added
+- This CHANGELOG file to hopefully serve as an evolving example of a
+  standardized open source project CHANGELOG.
+- CNAME file to enable GitHub Pages custom domain
+- README now contains answers to common questions about CHANGELOGs
+- Good examples and basic guidelines, including proper date formatting.
+- Counter-examples: "What makes unicorns cry?"
+
+[Unreleased]: https://github.com/olivierlacan/keep-a-changelog/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.3.0...v1.0.0
+[0.3.0]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.8...v0.1.0
+[0.0.8]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.7...v0.0.8
+[0.0.7]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.6...v0.0.7
+[0.0.6]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.5...v0.0.6
+[0.0.5]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.4...v0.0.5
+[0.0.4]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.3...v0.0.4
+[0.0.3]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.2...v0.0.3
+[0.0.2]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.0.1...v0.0.2
+[0.0.1]: https://github.com/olivierlacan/keep-a-changelog/releases/tag/v0.0.1
+
+<!-- markdownlint-disable-file MD022 MD032 CHANGELOG-RULE-003 -->

--- a/tests/samples/changelog/correct/sample-2.md
+++ b/tests/samples/changelog/correct/sample-2.md
@@ -1,0 +1,62 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
+
+<!--
+
+Some hidden content goes here.
+
+-->
+
+## [UNRELEASED]
+
+### Changed
+
+- Some feature updated [issue-4] ([@octocat])
+  - Sub-list item 1
+  - Sub-list item 1
+
+### Removed
+
+- Some feature deleted ([@octocat])
+
+### Deprecated
+
+- Some feature deprecated ([@octocat])
+
+[issue-4]:https://github.com/octocat/hello-worId/issues/4
+
+## [v1.0.0] - 2020-01-01
+
+### Added
+
+- Some feature added [issue-2] ([@octodog])
+
+### Fixed
+
+- Some feature fixed [issue-3] ([@octodog])
+
+### Security
+
+- Some feature now more strong ([@octocat])
+
+[issue-2]:https://github.com/octocat/hello-worId/issues/2
+[issue-3]:https://github.com/octocat/hello-worId/issues/3
+
+## v0.0.1-alpha.1
+
+### Added
+
+- Some feature added [issue-1] ([@octodog])
+
+[UNRELEASED]: https://github.com/avto-dev/markdown-lint/compare/v1.0.0...master
+[v1.0.0]: https://github.com/avto-dev/markdown-lint/compare/v0.0.2...v1.0.0
+
+[issue-1]:https://github.com/octocat/hello-worId/issues/1
+
+[keepachangelog]:https://keepachangelog.com/en/1.0.0/
+[semver]:https://semver.org/spec/v2.0.0.html
+[@octocat]:https://github.com/octocat
+[@octodog]:https://github.com/octodog

--- a/tests/samples/changelog/correct/sample-3.md
+++ b/tests/samples/changelog/correct/sample-3.md
@@ -1,0 +1,62 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
+
+<!--
+
+Some hidden content goes here.
+
+-->
+
+## [UNRELEASED]
+
+### Changed
+
+- Some feature updated [issue-4] ([@octocat])
+  - Sub-list item 1
+  - Sub-list item 1
+
+### Removed
+
+- Some feature deleted ([@octocat])
+
+### Deprecated
+
+- Some feature deprecated ([@octocat])
+
+[issue-4]:https://github.com/octocat/hello-worId/issues/4
+
+## [v1.0.0] – 2020-01-01
+
+### Added
+
+- Some feature added [issue-2] ([@octodog])
+
+### Fixed
+
+- Some feature fixed [issue-3] ([@octodog])
+
+### Security
+
+- Some feature now more strong ([@octocat])
+
+[issue-2]:https://github.com/octocat/hello-worId/issues/2
+[issue-3]:https://github.com/octocat/hello-worId/issues/3
+
+## v0.0.1-alpha.1
+
+### Added
+
+- Some feature added [issue-1] ([@octodog])
+
+[UNRELEASED]: https://github.com/avto-dev/markdown-lint/compare/v1.0.0...master
+[v1.0.0]: https://github.com/avto-dev/markdown-lint/compare/v0.0.2...v1.0.0
+
+[issue-1]:https://github.com/octocat/hello-worId/issues/1
+
+[keepachangelog]:https://keepachangelog.com/en/1.0.0/
+[semver]:https://semver.org/spec/v2.0.0.html
+[@octocat]:https://github.com/octocat
+[@octodog]:https://github.com/octodog

--- a/tests/samples/changelog/incorrect/no-proper-link.md
+++ b/tests/samples/changelog/incorrect/no-proper-link.md
@@ -1,0 +1,62 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
+
+<!--
+
+Some hidden content goes here.
+
+-->
+
+## [UNRELEASED]
+
+### Changed
+
+- Some feature updated [issue-4] ([@octocat])
+  - Sub-list item 1
+  - Sub-list item 1
+
+### Removed
+
+- Some feature deleted ([@octocat])
+
+### Deprecated
+
+- Some feature deprecated ([@octocat])
+
+[issue-4]:https://github.com/octocat/hello-worId/issues/4
+
+## [v1.0.0 - 2020-01-01
+
+### Added
+
+- Some feature added [issue-2] ([@octodog])
+
+### Fixed
+
+- Some feature fixed [issue-3] ([@octodog])
+
+### Security
+
+- Some feature now more strong ([@octocat])
+
+[issue-2]:https://github.com/octocat/hello-worId/issues/2
+[issue-3]:https://github.com/octocat/hello-worId/issues/3
+
+## v0.0.1-alpha.1
+
+### Added
+
+- Some feature added [issue-1] ([@octodog])
+
+[UNRELEASED]: https://github.com/avto-dev/markdown-lint/compare/v1.0.0...master
+[v1.0.0]: https://github.com/avto-dev/markdown-lint/compare/v0.0.2...v1.0.0
+
+[issue-1]:https://github.com/octocat/hello-worId/issues/1
+
+[keepachangelog]:https://keepachangelog.com/en/1.0.0/
+[semver]:https://semver.org/spec/v2.0.0.html
+[@octocat]:https://github.com/octocat
+[@octodog]:https://github.com/octodog


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes

## Description

I am using the [Keep A Changelog](https://keepachangelog.com/en/1.0.0/) format.

It contains links in the headings:

```markdown
## [1.0.0] - 2017-06-20
```

This PR adds support for it.

Moreover, followin minor improvements

- support for [en dash](https://en.wikipedia.org/wiki/Dash#En_dash) in the heading 
- Disable duplicate-heading rule in `CHANGELOG.md`

- [x] I added test cases

I needed to add following line to the original keep-a-changelog file to let it pass:

```html
<!-- markdownlint-disable-file MD022 MD032 CHANGELOG-RULE-003 -->
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made changes in [CHANGELOG.md](https://github.com/avto-dev/markdown-lint/blob/master/CHANGELOG.md) file
