### PR TITLE
Allow passing of multiple parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## Unreleased
+
+### Added
+
+- Added support for passing multiple parameters to markdown-lint.
+
 ## v1.1.0 - 2020-02-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 
 ### Added
 
-- Added support for passing multiple parameters to markdown-lint
+- Added support for passing multiple parameters to `markdown-lint` [#3]
+
+[#3]:https://github.com/avto-dev/markdown-lint/pull/3
 
 ## v1.1.0 - 2020-02-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 
 ### Added
 
-- Added support for passing multiple parameters to markdown-lint.
+- Added support for passing multiple parameters to markdown-lint
 
 ## v1.1.0 - 2020-02-11
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -22,4 +22,4 @@ if [ ! -z $INPUT_IGNORE ] && [ "$INPUT_IGNORE" != "" ]; then
   RUN_ARGS="$RUN_ARGS --ignore $INPUT_IGNORE";
 fi;
 
-exec /usr/local/bin/markdownlint $RUN_ARGS "$@"
+exec /usr/local/bin/markdownlint $RUN_ARGS $@


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No

## Description

I'd like to pass multiple parameters

```yaml
          args: docs/ CHANGELOG.md README.md
```

Currently, the action passes these surrounded by quotes which leads to an error message:

![grafik](https://user-images.githubusercontent.com/1366654/83077275-5c669300-a077-11ea-996d-b40e48e8cd67.png)

Reason: The tool receives that as one parameter which it doesn't like. It needs three.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made changes in [CHANGELOG.md](https://github.com/avto-dev/markdown-lint/blob/master/CHANGELOG.md) file
