### PR TITLE
Install BASH to enable and support globstar (**)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## Unreleased
+
+- Fix support for globstar (`**`) by changing the shell to bash [#6]
+
 ## v1.2.0 - 2020-05-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
-## Unreleased
+## v1.2.0 - 2020-06-19
 
-- Fix support for globstar (`**`) by changing the shell to bash [#6]
+### Added
+
+- Support for globstar (`**`) by changing the shell to bash [#6]
 
 ## v1.2.0 - 2020-05-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 
 - Support for globstar (`**`) by changing the shell to bash [#6]
 
+[#6]:https://github.com/avto-dev/markdown-lint/pull/6
+
 ## v1.2.0 - 2020-05-28
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ LABEL \
   org.label-schema.vendor="avto-dev" \
   org.label-schema.vcs-url="https://github.com/avto-dev/markdown-lint"
 
+RUN apk add --no-cache bash
 RUN set -x \
   # package page: <https://github.com/igorshubovych/markdownlint-cli>
   && npm install -g markdownlint-cli \

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,4 +1,5 @@
-#!/bin/sh
+#!/bin/bash
+shopt -s globstar
 
 RUN_ARGS="";
 


### PR DESCRIPTION
# Description

| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | Kinda

## Issue
globstar doesn't work with the current container setup.

### Background
Node Alpine ships with `ash` as a default shell. The globbing behaviors for `ash` don't include globstar, which is handy linting many files. Globstar is supported in [glob](https://github.com/isaacs/node-glob/blob/master/README.md#glob-primer), upon which the underlying linter depends.

### Repro steps
From my understanding in `ash`, `**` is resolved as `*` and doesn't search recursively. You can observe this by creating a nested directory structure and the command over it:

```bash
my-files/
├── one/
│   └── linted.md
│   ├── two/
│   │   └── not-linted.md
```

```bash
$ docker run --rm \
    -v "$(pwd)/my-files:/my-files:ro" \
    avtodev/markdown-lint:v1 \
    '/my-files/**/*.md'
```

With the `markdownlint-cli` running on a more robust shell, the expected behavior is that both files would be linted, but with `ash` only the first is.

## Proposed fix
* install bash in the dockerfile via apk.
  * pass no-cache to keep the size small.
* run the entrypoint with bash and enable globstar.

With these changes, the above example will lint both markdown files.

### Cost
This increases container size by ~2MB from my tests.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (commit history)
- [x] I have made changes in [CHANGELOG.md](https://github.com/avto-dev/markdown-lint/blob/master/CHANGELOG.md) file
