### PR TITLE
Fix variable checks and argument splitting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
-## [Unreleased]
+## UNRELEASED
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## [Unreleased]
+
+### Changed
+
+- Fix quoting of `INPUT_*` env variables to allow multiple arguments in 1 env var
+
 ## v1.3.0 - 2020-06-19
 
 ### Added

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -3,24 +3,26 @@ shopt -s globstar
 
 RUN_ARGS="";
 
-if [ ! -z $INPUT_RULES ] && [ "$INPUT_RULES" != "" ]; then
+if [ "$INPUT_RULES" != "" ]; then
   RUN_ARGS="$RUN_ARGS --rules $INPUT_RULES";
 fi;
 
-if [ ! -z $INPUT_CONFIG ] && [ "$INPUT_CONFIG" != "" ]; then
+if [ "$INPUT_CONFIG" != "" ]; then
   RUN_ARGS="$RUN_ARGS --config $INPUT_CONFIG";
 fi;
 
-if [ ! -z $INPUT_FIX ] && [ "$INPUT_FIX" = "true" ]; then
+if [ "$INPUT_FIX" = "true" ]; then
   RUN_ARGS="$RUN_ARGS --fix";
 fi;
 
-if [ ! -z $INPUT_OUTPUT ] && [ "$INPUT_OUTPUT" != "" ]; then
+if [ "$INPUT_OUTPUT" != "" ]; then
   RUN_ARGS="$RUN_ARGS --output $INPUT_OUTPUT";
 fi;
 
-if [ ! -z $INPUT_IGNORE ] && [ "$INPUT_IGNORE" != "" ]; then
+if [ "$INPUT_IGNORE" != "" ]; then
   RUN_ARGS="$RUN_ARGS --ignore $INPUT_IGNORE";
 fi;
 
+# Do not quote "$@" as Github Actions passes each argument as a single arg.
+# So 'args: --fix foo bar.md'  would be treated as a single string and not be parsed by markdownlint
 exec /usr/local/bin/markdownlint $RUN_ARGS $@


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No

## Description

This removes superflous checks of the form `[ ! -z $INPUT_RULES ] `: `! -z` is `-n` which is `!= ""` and that is already checked

This allows to pass multiple values in e.g `ignore` where I used `"external --ignore data"` as a workaround for #7

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made changes in [CHANGELOG.md](https://github.com/avto-dev/markdown-lint/blob/master/CHANGELOG.md) file
