### PR TITLE
GitHub action ignore arg fixed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,8 +61,12 @@ jobs: # Docs: <https://help.github.com/en/articles/workflow-syntax-for-github-ac
           config: '/lint/config/changelog.yml'
           args: './CHANGELOG.md'
           ignore: './foo ./bar ./foo\ bar'
+        env:
+          DEBUG: 'true'
 
       - name: Run current action using stub markdown file
         uses: ./
         with:
           args: './tests/correct.md'
+        env:
+          DEBUG: 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ on:
 jobs: # Docs: <https://help.github.com/en/articles/workflow-syntax-for-github-actions>
   tests:
     name: Execute provided tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Check out code
         uses: actions/checkout@v2
@@ -32,7 +32,7 @@ jobs: # Docs: <https://help.github.com/en/articles/workflow-syntax-for-github-ac
 
   docker-image:
     name: Build docker image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Check out code
         uses: actions/checkout@v2
@@ -47,7 +47,7 @@ jobs: # Docs: <https://help.github.com/en/articles/workflow-syntax-for-github-ac
 
   run-as-action:
     name: Run action
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Check out code
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs: # Docs: <https://help.github.com/en/articles/workflow-syntax-for-github-ac
           rules: '/lint/rules/changelog.js'
           config: '/lint/config/changelog.yml'
           args: './CHANGELOG.md'
-          ignore: './foo ./bar ./foo\ bar'
+          ignore: './foo ./bar'
         env:
           DEBUG: 'true'
 
@@ -68,5 +68,6 @@ jobs: # Docs: <https://help.github.com/en/articles/workflow-syntax-for-github-ac
         uses: ./
         with:
           args: './tests/correct.md'
+          ignore: './foo ./bar'
         env:
           DEBUG: 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,7 @@ jobs: # Docs: <https://help.github.com/en/articles/workflow-syntax-for-github-ac
           rules: '/lint/rules/changelog.js'
           config: '/lint/config/changelog.yml'
           args: './CHANGELOG.md'
+          ignore: './foo ./bar ./foo\ bar'
 
       - name: Run current action using stub markdown file
         uses: ./

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   update-git-tag: # Reason: <https://github.com/actions/toolkit/blob/master/docs/action-versioning.md#recommendations>
     name: Update latest major git tag
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Check out code
         uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## UNRELEASED
+
+### Changed
+
+- `markdownlint-cli` version updated up to `0.23.2` (from `0.26.0`)
+
+### Fixed
+
+- Multiple files ignoring (you can run current action `with: ingore: 'foo.md bar.md'` with space delimiter for multiple `--ignore` flag appending) [#7]
+
+[#7]:https://github.com/avto-dev/markdown-lint/issues/7
+
 ## v1.4.0 - 2020-09-25
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 
 ### Fixed
 
-- Multiple files ignoring (you can run current action `with: ingore: 'foo.md bar.md'` with space delimiter for multiple `--ignore` flag appending) [#7]
+- Multiple files ignoring (you can run current action `with: ignore: 'foo.md bar.md'` with space delimiter for multiple `--ignore` flag appending) [#7]
 
 [#7]:https://github.com/avto-dev/markdown-lint/issues/7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 
 ### Changed
 
-- `markdownlint-cli` version updated up to `0.23.2` (from `0.26.0`)
+- `markdownlint-cli` version updated up to `0.26.0` (from `0.23.2`)
 
 ### Fixed
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:12-alpine as builder
 
-ARG MARKDOWN_CLI_VERSION="0.23.2"
+ARG MARKDOWN_CLI_VERSION="0.26.0"
 
 # install packages
 RUN set -x \

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ jobs:
         rules: '/lint/rules/changelog.js'
         config: '/lint/config/changelog.yml'
         args: './CHANGELOG.md'
+        ignore: './one_file.md ./another_file.md' # multiple files must be separated with single space
 
     # Or using current repository as action:
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ $ docker run --rm \
     /CHANGELOG.md
 ```
 
-or 
+or
 
 ```bash
 $ docker run --rm \
@@ -88,7 +88,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Lint changelog file
-      uses: docker://avtodev/markdown-lint:v1
+      uses: docker://avtodev/markdown-lint:v1 # fastest way
       with:
         rules: '/lint/rules/changelog.js'
         config: '/lint/config/changelog.yml'

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -20,9 +20,11 @@ if [ "$INPUT_OUTPUT" != "" ]; then
 fi;
 
 if [ "$INPUT_IGNORE" != "" ]; then
-  RUN_ARGS="$RUN_ARGS --ignore $INPUT_IGNORE";
+  for ignore in $INPUT_IGNORE; do
+    RUN_ARGS="$RUN_ARGS --ignore $ignore";
+  done
 fi;
 
 # Do not quote "$@" as Github Actions passes each argument as a single arg.
-# So 'args: --fix foo bar.md'  would be treated as a single string and not be parsed by markdownlint
+# So 'args: --fix foo bar.md' would be treated as a single string and not be parsed by markdownlint
 exec /usr/local/bin/markdownlint $RUN_ARGS $@

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -25,6 +25,11 @@ if [ "$INPUT_IGNORE" != "" ]; then
   done
 fi;
 
+if [ "$DEBUG" = "true" ]; then
+  printenv | sort;
+  echo "$RUN_ARGS";
+fi;
+
 # Do not quote "$@" as Github Actions passes each argument as a single arg.
 # So 'args: --fix foo bar.md' would be treated as a single string and not be parsed by markdownlint
 exec /usr/local/bin/markdownlint $RUN_ARGS $@


### PR DESCRIPTION
## Description

### Changed

- `markdownlint-cli` version updated up to `0.26.0` (from `0.23.2`)

### Fixed

- Multiple files ignoring (you can run current action `with: ignore: 'foo.md bar.md'` with space delimiter for multiple `--ignore` flag appending)

Fixes #7

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in `CHANGELOG.md` file

<!--

About your changes in `CHANGELOG.md`:

* Add new version header like `## v1.x.x` or `## UNRELEASED`, if it does not exists
* Add description under `added`/`changed`/`fixed` sections
* Add reference to closed issues `[#000]`
* Add link to issue in the end of document

-->
