### PR TITLE
Fix docker image in README.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## v1.5.1 - 2021-09-10
+
+### Fixed
+
+- Docker image name in example part of `README.md`
+
 ## v1.5.0 - 2021-01-26
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ jobs:
     # Or using current repository as action:
 
     - name: Lint changelog file
-      uses: avto-dev/markdown-lint@v1
+      uses: avtodev/markdown-lint@v1
       with:
         rules: '/lint/rules/changelog.js'
         config: '/lint/config/changelog.yml'


### PR DESCRIPTION
Wrong image name in README.md

Was
```
uses: avto-dev/markdown-lint@v1
```

Now
```
uses: avtodev/markdown-lint@v1
```

## Description

<!--

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

-->

Fixes #14 

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in `CHANGELOG.md` file

<!--

About your changes in `CHANGELOG.md`:

* Add new version header like `## v1.x.x` or `## UNRELEASED`, if it does not exists
* Add description under `added`/`changed`/`fixed` sections
* Add reference to closed issues `[#000]`
* Add link to issue in the end of document

-->
