### PR TITLE
Fix badge with `build` and `version` statuses in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,10 +110,10 @@ jobs:
 MIT. Use anywhere for your pleasure.
 
 [badge_release]:https://img.shields.io/github/v/release/avto-dev/markdown-lint?include_prereleases&style=flat-square&maxAge=10
-[badge_ci]:https://img.shields.io/github/workflow/status/avto-dev/markdown-lint/CI?style=flat-square&maxAge=10
+[badge_ci]:https://img.shields.io/github/actions/workflow/status/avto-dev/markdown-lint/ci.yml
 [badge_pulls]:https://img.shields.io/docker/pulls/avtodev/markdown-lint.svg?style=flat-square&maxAge=30
 [badge_issues]:https://img.shields.io/github/issues/avto-dev/markdown-lint.svg?style=flat-square&maxAge=30
-[badge_build]:https://img.shields.io/docker/cloud/build/avtodev/markdown-lint.svg?style=flat-square&maxAge=30
+[badge_build]:https://img.shields.io/docker/v/avtodev/markdown-lint
 [badge_license]:https://img.shields.io/github/license/avto-dev/markdown-lint.svg?style=flat-square&maxAge=30
 [link_hub]:https://hub.docker.com/r/avtodev/markdown-lint/
 [link_hub_tags]:https://hub.docker.com/r/avtodev/markdown-lint/tags


### PR DESCRIPTION
## Description

Fix badge with `build` and `version` statuses in README.md

Before:

<img width="874" alt="image" src="https://github.com/avto-dev/markdown-lint/assets/1460709/81f50f01-8b3b-4b05-9776-165baff8fd9f">

After fixes:

<img width="699" alt="image" src="https://github.com/avto-dev/markdown-lint/assets/1460709/5e471075-33b2-438c-a749-aecdfb50c7cc">


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in `CHANGELOG.md` file

<!--

About your changes in `CHANGELOG.md`:

* Add new version header like `## v1.x.x` or `## UNRELEASED`, if it does not exists
* Add description under `added`/`changed`/`fixed` sections
* Add reference to closed issues `[#000]`
* Add link to issue in the end of document

-->
